### PR TITLE
changed type of variable n in hmmc2.c/main to uint64_t 

### DIFF
--- a/src/hmmc2.c
+++ b/src/hmmc2.c
@@ -177,7 +177,7 @@ usage(char *pgm)
 int main(int argc, char *argv[])
 {
   int              i, j;
-  int              n;
+  uint64_t              n;
   int              eod;
   int              size;
 


### PR DESCRIPTION
to prevent crashes when server sends more than 2GB of data to client.