### PR TITLE
Travis pipeline for testing on x86_64 linux, powerpc, and darwin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ src/impl*/*_utest
 src/impl*/*_benchmark
 documentation/userguide/copyright.tex
 documentation/userguide/titlepage.tex
+documentation/userguide/titlepage_daemon.tex
 documentation/man/*.man
 libdivsufsort/divsufsort.h
 libdivsufsort/libdivsufsort.a
@@ -46,3 +47,4 @@ src/makehmmerdb
 src/nhmmer
 src/nhmmscan
 src/phmmer
+autom4te.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: minimal
+
+services:
+  - docker
+
+env:
+  global:
+    - PATH=$HOME/bin:$PATH
+
+matrix:
+  include:
+    - env: TARGET=x86_64-pc-linux-gnu
+      name: x86_64-pc-linux-gnu
+    - env: TARGET=powerpc-unknown-linux-gnu
+      name: powerpc-unknown-linux-gnu
+    - os: osx
+      env: TARGET=x86_64-apple-darwin
+      name: x86_64-apple-darwin
+
+before_install:
+  - bash <(curl -fsSL https://raw.githubusercontent.com/horta/port-of-hmmer/master/ci/travis.sh)
+
+script:
+  - sandbox_run git clone -b develop https://github.com/EddyRivasLab/easel.git
+  - sandbox_run ln -s easel/aclocal.m4 aclocal.m4
+  - sandbox_run autoconf
+  - sandbox_run ./configure
+  - sandbox_run make
+  - sandbox_run make check
+
+notifications:
+  email:
+    recipients:
+      - danilo.horta@pm.me
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## HMMER - biological sequence analysis using profile HMMs
 
+[![Travis](https://img.shields.io/travis/com/horta/hmmer/eddy-develop.svg?label=linux%20%26%20macos%20builds)](https://travis-ci.com/horta/hmmer)
+
 [HMMER](http://hmmer.org) searches biological sequence databases for
 homologous sequences, using either single sequences or multiple
 sequence alignments as queries. HMMER implements a technology called


### PR DESCRIPTION
This allows for automatically testing HMMER3 on the x86_64-pc-linux-gnu, powerpc-unknown-linux-gnu, and x86_64-apple-darwin platforms.

It depends on another github repo, [port-of-hammer](https://github.com/horta/port-of-hmmer), that I would happily hand over to EddyRivasLab organization if needed. The same applies to [hortaebi/port-of-hammer](https://cloud.docker.com/repository/docker/hortaebi/port-of-hmmer).