### PR TITLE
Fix a typo in variable name.

### DIFF
--- a/src/p7_profile.c
+++ b/src/p7_profile.c
@@ -395,7 +395,7 @@ p7_profile_GetT(const P7_PROFILE *gm, char st1, int k1, char st2, int k2, float 
   if (st1 == p7T_X || st2 == p7T_X) return eslOK;
   if (st1 == p7T_B && st2 == p7T_I) return eslOK;
   if (st1 == p7T_B && st2 == p7T_D) return eslOK;
-  if (st1 == p7T_I && st1 == p7T_E) return eslOK;
+  if (st1 == p7T_I && st2 == p7T_E) return eslOK;
 
   /* Now we're sure this is a profile trace, as it should usually be. */
   switch (st1) {


### PR DESCRIPTION
The original check (`if (st1 == p7T_I && st1 == p7T_E) return eslOK;`) would never pass. With the typo fixed, this should work as expected.