### PR TITLE
Use the current repo for cloning easel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - SQC_NONZERO_EXIT=1
 
 script:
-  - git clone -b develop https://github.com/EddyRivasLab/easel.git
+  - git clone -b develop https://github.com/${TRAVIS_REPO_SLUG/hmmer/easel}.git
   - ln -s easel/aclocal.m4 aclocal.m4
   - autoconf
   - ./configure


### PR DESCRIPTION
This allows for cloning easel from the current repo.

As in my case, that line gets translated to

```
git clone -b develop https://github.com/horta/easel.git
```
