### PR TITLE
esl_sqio_ReadBlock() uses new argument max_init_window

### DIFF
--- a/src/hmmsearch.c
+++ b/src/hmmsearch.c
@@ -1342,7 +1342,7 @@ thread_loop(ESL_THREADS *obj, ESL_WORK_QUEUE *queue, ESL_SQFILE *dbfp, int n_tar
         block->count = 0;
         sstatus = eslEOF;
       } else {
-        sstatus = esl_sqio_ReadBlock(dbfp, block, -1, n_targetseqs, FALSE);
+        sstatus = esl_sqio_ReadBlock(dbfp, block, -1, n_targetseqs, /*max_init_window=*/FALSE, FALSE);
         n_targetseqs -= block->count;
       }
 

--- a/src/jackhmmer.c
+++ b/src/jackhmmer.c
@@ -1643,7 +1643,7 @@ thread_loop(ESL_THREADS *obj, ESL_WORK_QUEUE *queue, ESL_SQFILE *dbfp)
   while (sstatus == eslOK)
     {
       block = (ESL_SQ_BLOCK *) newBlock;
-      sstatus = esl_sqio_ReadBlock(dbfp, block, -1, -1, FALSE);
+      sstatus = esl_sqio_ReadBlock(dbfp, block, -1, -1, /*max_init_window=*/FALSE, FALSE);
       if (sstatus == eslEOF)
 	{
 	  if (eofCount < esl_threads_GetWorkerCount(obj)) sstatus = eslOK;

--- a/src/makehmmerdb.c
+++ b/src/makehmmerdb.c
@@ -607,7 +607,7 @@ main(int argc, char **argv)
     }
 
     
-    status = esl_sqio_ReadBlock(sqfp, block, block_size, -1, alphatype != eslAMINO);
+    status = esl_sqio_ReadBlock(sqfp, block, block_size, -1, /*max_init_window=*/FALSE, alphatype != eslAMINO);
     if (status == eslEOF) continue;
     if (status != eslOK)  esl_fatal("Parse failed (sequence file %s): status:%d\n%s\n",
                                                   sqfp->filename, status, esl_sqfile_GetErrorBuf(sqfp));

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -1422,7 +1422,7 @@ thread_loop(WORKER_INFO *info, ID_LENGTH_LIST *id_length_list, ESL_THREADS *obj,
         block->count = 0;
         sstatus = eslEOF;
       } else {
-        sstatus = esl_sqio_ReadBlock(dbfp, block, info->pli->block_length, n_targetseqs, TRUE);
+        sstatus = esl_sqio_ReadBlock(dbfp, block, info->pli->block_length, n_targetseqs, /*max_init_window=*/FALSE, TRUE);
       }
 
       block->first_seqidx = info->pli->nseqs;

--- a/src/phmmer.c
+++ b/src/phmmer.c
@@ -1447,7 +1447,7 @@ thread_loop(ESL_THREADS *obj, ESL_WORK_QUEUE *queue, ESL_SQFILE *dbfp, int n_tar
         block->count = 0;
         sstatus = eslEOF;
       } else {
-        sstatus = esl_sqio_ReadBlock(dbfp, block, -1, n_targetseqs, FALSE);
+        sstatus = esl_sqio_ReadBlock(dbfp, block, -1, n_targetseqs, /*max_init_window=*/FALSE, FALSE);
         n_targetseqs -= block->count;
       }
 


### PR DESCRIPTION
This pull request accompanies and depends on infernal pull request
4 and easel pull request 46. It should only be accepted if those pull
requests are accepted also.

This pull request includes support for a new int (effectively boolean)
argument to the esl_sqio_ReadBlock() (both ascii and ncbi versions) of
<max_init_window>. When set to TRUE, this causes the function to
define windows identically for sequences regardless of their order
in a sequence file. When set to FALSE, this flag has *no* *effect*.

All hmmer calls in this pull request set <max_init_window> to FALSE
so these changes should have *no effect*.

In infernal, <max_init_window> is set to TRUE for some calls.

See the easel pull request 46 and infernal pull request 4 for more information.