### PR TITLE
Adds uint64_t casts to code that sets row pointers in p7_gmx_Create()…

### DIFF
--- a/src/p7_gmx.c
+++ b/src/p7_gmx.c
@@ -46,7 +46,7 @@ p7_gmx_Create(int allocM, int allocL)
 
   /* Set the row pointers. */
   for (i = 0; i <= allocL; i++) 
-    gx->dp[i] = gx->dp_mem + i * (allocM+1) * p7G_NSCELLS;
+    gx->dp[i] = gx->dp_mem + (uint64_t) i * (uint64_t) (allocM+1) * p7G_NSCELLS;
 
   /* Initialize memory that's allocated but unused, only to keep
    * valgrind and friends happy.
@@ -135,7 +135,7 @@ p7_gmx_GrowTo(P7_GMX *gx, int M, int L)
       gx->allocW = M+1;
       gx->validR = ESL_MIN(gx->ncells / gx->allocW, gx->allocR);
       for (i = 0; i < gx->validR; i++) 
-	gx->dp[i] = gx->dp_mem + i * (gx->allocW) * p7G_NSCELLS;
+        gx->dp[i] = gx->dp_mem + (uint64_t) i * (uint64_t) gx->allocW * p7G_NSCELLS;
     }
 
   gx->M      = 0;


### PR DESCRIPTION
This pull request offers a fix for a bug involving large P7_GMX
matrices, described below.

p7_gmx_utest seg faults in my hands when compiled with -O3 with gcc
7.3.0 when very large values of M and L are used. Specifically, a seg
fault occurs if a row pointer is set to 'gx->dp_mem + x' where 'x'
exceeds 2,147,483,647 (2^32-1, maximum value of an unsigned 32-bit
integer). That occurs if (L * (M+1) * 3) > 2,147,483,647, due to the
following loop in p7_gmx_Create():

```
  /* Set the row pointers. */
  for (i = 0; i <= allocL; i++) 
    gx->dp[i] = gx->dp_mem + i * (allocM+1) * p7G_NSCELLS;
```
and also due to the corresponding code in p7_gmx_GrowTo(). 

This table shows which L/M values cause seg faults or not and
demonstrates the importance of the 2^32-1 threshold:


| allocL |allocM |dp[L] ptr |  dp[L] ptr above maxint? | segfault? |
|---|---|---|---|---|
|10000 | 71581 | 2147460000 | no |            no|
|10000  |71582|  2147490000  |yes |           yes|
|71575 | 10000 | 2147464725 | no |            no|
|71576 | 10000  |2147494728 | yes|            yes|
|20000 | 35790 | 2147460000 | no |            no|
|20000 | 35791 | 2147520000 | yes |           yes|
|35789 | 20000 | 2147447367 | no |            no|
|35790 | 20000 | 2147507370 | yes  |          yes|

The seg faults go away if -O3 is not used, in my hands. One possible
clue as to why is that you get the following compiler warning IF you
hard-code the seg fault causing values of L and M into p7_gmx_Create.c
(so the compiler knows what values will be used, via explicit variable
assignment e.g. 'L=10000;' 'M=71582;'). If you do that, you get the
following warning when you compile:

```
./p7_gmx.c: In function 'p7_gmx_Create':
./p7_gmx.c:52:45: warning: iteration 10000 invokes undefined behavior [-Waggressive-loop-optimizations]
     gx->dp[i] = gx->dp_mem + i * (allocM+1) * p7G_NSCELLS;
./p7_gmx.c:51:3: note: within this loop
   for (i = 0; i <= allocL; i++)
   ^~~
```

I can get this warning to go away by adding the gcc flag
'-fno-aggressive-loop-optimizations' *but* I still get the seg fault,
so I'm not sure if 'aggressive loop optimizations' are the reason for
the seg fault or not.

A fix to prevent the seg fault that is included in this pull request
is to cast at least one of the values in the definition of the
gx->dp[i] pointer to a uint64_t, which (as far as I understand) forces
the compiler to treat that product as a uint64_t. An analogous change
needs to be made in p7_gmx_GrowTo(). With both changes, the seg fault
goes away. However, as noted above, I'm not sure why this fix works,
other than the one clue about aggressive loop optimizations.

I have not examined _Create() or _GrowTo() functions for other data
structures to see if they may be susceptible to this same issue.

Also, I'm not sure if/how this bug should be documented. It seems like
BUGTRAX is no more. I noticed iss159-nhmmer-overlap.py - do you want a
similar script for this (it would have to be perl, from me)? Note that
because this issue only occurs with huge matrices the quickest failing
p7_gmx_utest run in my hands takes about 2 minutes.