### PR TITLE
Force trace to be Reuse()'d after numeric overflow in p7_Decoding()

### DIFF
--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -1309,6 +1309,7 @@ serial_loop(WORKER_INFO *info, ID_LENGTH_LIST *id_length_list, ESL_SQFILE *dbfp,
       dbsq->idx = seq_id;
       p7_pli_NewSeq(info->pli, dbsq);
 
+      printf("%s\n", dbsq->name);
       if (info->pli->strands != p7_STRAND_BOTTOMONLY) {
 
         info->pli->nres -= dbsq->C; // to account for overlapping region of windows

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -1309,7 +1309,6 @@ serial_loop(WORKER_INFO *info, ID_LENGTH_LIST *id_length_list, ESL_SQFILE *dbfp,
       dbsq->idx = seq_id;
       p7_pli_NewSeq(info->pli, dbsq);
 
-      printf("%s\n", dbsq->name);
       if (info->pli->strands != p7_STRAND_BOTTOMONLY) {
 
         info->pli->nres -= dbsq->C; // to account for overlapping region of windows

--- a/src/p7_domaindef.c
+++ b/src/p7_domaindef.c
@@ -894,10 +894,7 @@ rescore_isolated_domain(P7_DOMAINDEF *ddef, P7_OPROFILE *om, const ESL_SQ *sq, c
       p7_Backward(sq->dsq + i-1, Ld, om, ox1, ox2, NULL);
 
       status = p7_Decoding(om, ox1, ox2, ox2);      /* <ox2> is now overwritten with post probabilities     */
-      if (status == eslERANGE) {                    /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-212] */
-          p7_trace_Reuse(ddef->tr);
-          return eslFAIL;
-      }
+      if (status == eslERANGE) { status = eslFAIL; goto ERROR; }  /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-212] */
 
       /* Find an optimal accuracy alignment */
       p7_OptimalAccuracy(om, ox2, ox1, &oasc);      /* <ox1> is now overwritten with OA scores              */

--- a/src/p7_domaindef.c
+++ b/src/p7_domaindef.c
@@ -894,7 +894,10 @@ rescore_isolated_domain(P7_DOMAINDEF *ddef, P7_OPROFILE *om, const ESL_SQ *sq, c
       p7_Backward(sq->dsq + i-1, Ld, om, ox1, ox2, NULL);
 
       status = p7_Decoding(om, ox1, ox2, ox2);      /* <ox2> is now overwritten with post probabilities     */
-      if (status == eslERANGE) return eslFAIL;      /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-212] */
+      if (status == eslERANGE) {                    /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-212] */
+          p7_trace_Reuse(ddef->tr);
+          return eslFAIL;
+      }
 
       /* Find an optimal accuracy alignment */
       p7_OptimalAccuracy(om, ox2, ox1, &oasc);      /* <ox1> is now overwritten with OA scores              */


### PR DESCRIPTION
In p7_domaindef.c, following a call to p7_Decoding(), line 897 was:
   if (status == eslERANGE) return eslFAIL;
The comment says this is the result of repetitive garbage [J3/119-212],
which is certainly the case that has caused it to fire in my hands (in nhmmer).

The eslFAIL return value is handled gracefully in the calling function,
but since it returns immediately, the normal end-of-function cleanup
wasn't happening. That skipped cleanup is basically just the line:
   p7_trace_Reuse(ddef->tr);

The result is that the next call to p7_OATrace() failed with:
   Fatal exception (source file optacc.c, line 233):
   trace not empty; needs to be Reuse()'d?
   Abort trap: 6

The solution (in this pull request) is to force the trace to be reused
before returning eslFAIL:
   if (status == eslERANGE) {
          p7_trace_Reuse(ddef->tr);
          return eslFAIL;
   }