### PR TITLE
Fix for iss#171: guessing query file format

### DIFF
--- a/documentation/man/nhmmer.man.in
+++ b/documentation/man/nhmmer.man.in
@@ -51,7 +51,7 @@ cannot come from stdin, because we can't rewind the
 streaming target database to search it with another profile. 
 
 .PP
-If the query is sequence-based,
+If the query is sequence-based (unaligned or aligned),
 a new file containing the HMM(s) built from the input(s) in 
 .I queryfile
 may optionally be produced, with the filename set using the 
@@ -479,30 +479,7 @@ reduced sensitivity. (minor tuning option)
 .SH OTHER OPTIONS
 
 
-.TP 
-.B \-\-qhmm 
-Assert that the input
-.I queryfile
-contains one or more profile HMMs, as built by 
-.BR hmmbuild . 
-
-.TP 
-.B \-\-qfasta 
-Assert that the input
-.I queryfile
-contains one or more unaligned sequences, stored in fasta format. 
- 
-.TP 
-.B \-\-qmsa 
-Assert that the input
-.I queryfile
-contains one or more sequence alignments. The format of
-the file may be specified with the  
-.B \-\-qformat 
-flag.
-
-
-.TP 
+.TP
 .BI \-\-qformat " <s>"
 Assert that input
 .I queryfile
@@ -515,7 +492,9 @@ include:
 .BR fasta ,
 .BR embl ,
 .BR genbank.
-Alignment formats also work;
+Alignment formats also work, and will serve as the
+basis for automatic creation of a profile HMM used for
+searching;
 common choices include:
 .BR stockholm , 
 .BR a2m ,

--- a/documentation/man/nhmmer.man.in
+++ b/documentation/man/nhmmer.man.in
@@ -368,12 +368,6 @@ abnormally heavy load.
 .SH OPTIONS FOR SPECIFYING THE ALPHABET
 
 .TP
-.B \-\-amino
-Assert that sequences in 
-.I msafile
-are protein, bypassing alphabet autodetection.
-
-.TP
 .B \-\-dna
 Assert that sequences in
 .I msafile
@@ -504,8 +498,18 @@ common choices include:
 .BR phylip .
 For more information, and for codes for some less common formats,
 see main documentation.
-The string
-.I <s>
+
+
+.TP
+.BI \-\-qsingle_seqs
+Force
+.I queryfile
+to be read as individual sequences, even if it is in
+an msa format. For example, if the input is in aligned
+.BR stockholm
+format, the
+.BR \-\-qsingle_seqs
+ flag will cause each sequence in that alignment to be used as a seperate query sequence.
 
 .TP
 .BI \-\-tformat " <s>"

--- a/documentation/userguide/tutorial.tex
+++ b/documentation/userguide/tutorial.tex
@@ -1288,12 +1288,12 @@ sequence in a much more memory-efficient manner than
 The \mono{nhmmer} and \mono{nhmmscan} programs are designed for
 memory-efficient DNA profile searches of long DNA sequences. They were
 developed in concert with the Dfam database (\url{dfam.org}), which
-provides of alignments and profiles of many common DNA repeat elements
+provides alignments and profiles of DNA repeat elements
 for several important genomes.  The alignment
 \mono{tutorial/MADE1.sto} is a representative alignment of 100 human
 MADE1 transposable elements, a subset of the Dfam MADE1
 alignment. We'll use the MADE1 alignment to show how
-\mono{nhmmer}/\mono{nhmmscan} work, which are similar to
+\mono{nhmmer}/\mono{nhmmscan} work; these are similar to
 \mono{hmmsearch}/\mono{hmmscan}.
 
 \subsection{Step 1: build a profile with hmmbuild}
@@ -1332,19 +1332,18 @@ database. It is a FASTA format file containing one 330Kb long DNA
 sequence extracted from human chromosome 1.
 
 \mono{nhmmer} accepts a target DNA sequence database in the same
-formats as hmmsearch (typically FASTA). For the query, it accepts
-either a profile file as produced above by hmmbuild, or a file
-containing either one DNA sequence or an alignment of multiple DNA
-sequences.
+formats as hmmsearch (typically FASTA). It accepts a query file
+of one or more nucleotide queries; each
+query may be either a profile model built using
+\mono{hmmbuild},
+a sequence alignment, or a single sequence.
 
 If a sequence or alignment is used as query input, \mono{nhmmer}
 internally produces the profile for that alignment\marginnote{Using
   default hmmbuild parameters; if you want more control, explicitly
   built the profile with hmmbuild.}, then searches with that
-profile. The profile produced in this way is automatically saved to
-disk, and the default file name is chosen by appending ``.hmm'' to the
-name of the sequence file name. This can be overridden with the
-\mono{-{}-hmmout} flag.
+profile. The profile produced in this way can be written to a file
+specified by the \mono{-{}-hmmout} flag.
 
 To search \mono{dna\_target.fa} with our \mono{MADE1.hmm} profile:
 

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -475,11 +475,11 @@ nhmmer_open_seq_file (struct cfg_s *cfg, ESL_SQFILE **qfp_sq, ESL_ALPHABET **abc
                         status = esl_sqfile_GuessAlphabet(*qfp_sq, &q_type);
             }
             if (status == eslEFORMAT) p7_Fail("Parse failed (sequence file %s):\n%s\n", (*qfp_sq)->filename, esl_sqfile_GetErrorBuf(*qfp_sq));
-            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for the %s%squery file %s\n", esl_sqio_DecodeFormat(cfg->qfmt), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted "), cfg->queryfile);
+            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for the %s%squery file %s\n", (cfg->qfmt==eslUNKNOWN ? "" : esl_sqio_DecodeFormat(cfg->qfmt)), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted"), cfg->queryfile);
             *abc = esl_alphabet_Create(q_type);
         }
         if (!((*abc)->type == eslRNA || (*abc)->type == eslDNA))
-            p7_Fail("Invalid alphabet type in the %s%squery file %s. Expect DNA or RNA\n", esl_sqio_DecodeFormat(cfg->qfmt), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted "), cfg->queryfile);
+            p7_Fail("Invalid alphabet type in the %s%squery file %s. Expect DNA or RNA\n", (cfg->qfmt==eslUNKNOWN ? "" : esl_sqio_DecodeFormat(cfg->qfmt)), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted "), cfg->queryfile);
 
         esl_sqfile_SetDigital(*qfp_sq, *abc);
         // read first sequence

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -475,17 +475,17 @@ nhmmer_open_seq_file (struct cfg_s *cfg, ESL_SQFILE **qfp_sq, ESL_ALPHABET **abc
                         status = esl_sqfile_GuessAlphabet(*qfp_sq, &q_type);
             }
             if (status == eslEFORMAT) p7_Fail("Parse failed (sequence file %s):\n%s\n", (*qfp_sq)->filename, esl_sqfile_GetErrorBuf(*qfp_sq));
-            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for query file %s\n", cfg->queryfile);
+            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for the %s%squery file %s\n", esl_sqio_DecodeFormat(cfg->qfmt), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted "), cfg->queryfile);
             *abc = esl_alphabet_Create(q_type);
         }
         if (!((*abc)->type == eslRNA || (*abc)->type == eslDNA))
-            p7_Fail("Invalid alphabet type in query for nhmmer. Expect DNA or RNA\n");
+            p7_Fail("Invalid alphabet type in the %s%squery file %s. Expect DNA or RNA\n", esl_sqio_DecodeFormat(cfg->qfmt), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted "), cfg->queryfile);
 
         esl_sqfile_SetDigital(*qfp_sq, *abc);
         // read first sequence
         *qsq = esl_sq_CreateDigital(*abc);
         status = esl_sqio_Read(*qfp_sq, *qsq);
-        if (status != eslOK) p7_Fail("reading sequence from file %s (%d)\n", cfg->queryfile, status);
+        if (status != eslOK) p7_Fail("reading sequence from file %s (%d): \n%s\n", cfg->queryfile, status, esl_sqfile_GetErrorBuf(*qfp_sq));
     }
     return status;
 }
@@ -590,10 +590,10 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
    */
   if (esl_sqio_IsAlignment(cfg->qfmt) /* msa file */ && !esl_opt_IsOn(go, "--qsingle_seqs") /* msa intent is not overridden */) {
       status = nhmmer_open_msa_file(cfg, &qfp_msa, &abc, &msa);
-      if (status != eslOK) p7_Fail("Error reading msa from file %s (%d)\n", cfg->queryfile, status);
+      if (status != eslOK) p7_Fail("Error reading msa from the %s-formatted file %s (%d)\n", esl_sqio_DecodeFormat(cfg->qfmt), cfg->queryfile, status);
   } else if (cfg->qfmt != eslSQFILE_UNKNOWN /* sequence file */) {
       status = nhmmer_open_seq_file(cfg, &qfp_sq, &abc, &qsq, esl_opt_IsOn(go, "--qsingle_seqs"));
-      if (status != eslOK) p7_Fail("Error reading sequence from file %s (%d)\n", cfg->queryfile, status);
+      if (status != eslOK) p7_Fail("Error reading sequence from the %s-formatted file %s (%d)\n", esl_sqio_DecodeFormat(cfg->qfmt), cfg->queryfile, status);
   }
 
 

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -587,6 +587,8 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
    *  - 0 is an unknown/unassigned format (eslSQFILE_UNKNOWN, eslMSAFILE_UNKNOWN)
    *  - <=100 is reserved for sqio, for unaligned formats
    *  - >100  is reserved for msa, for aligned formats
+   *
+   *  These values follow the rules laid out in esl_msa.h and esl_sqio.h
    */
   if (cfg->qfmt > 100 /* msa file */) {
       status = nhmmer_open_msa_file(cfg, &qfp_msa, &abc, &msa);

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -591,7 +591,7 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
       status = nhmmer_open_seq_file(cfg, &qfp_sq, &abc, &qsq);
       if (status != eslOK) p7_Fail("Error reading sequence from file %s (%d)\n", cfg->queryfile, status);
   }
-  
+
 
 /* (2)
  * Guessing query format.
@@ -629,7 +629,7 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
                   if ( qfp_msa->format == eslMSAFILE_AFA || qfp_msa->format == eslMSAFILE_A2M) {
                       /* this could just be a sequence file with o single sequence (in which case, fall through
                        * to the "sequence" case), or with several same-sized sequences (in which case ask for guidance) */
-                      if (msa->nseq > 1) p7_Fail("Unable to guess query file type; please specify (--qformat)");
+                      if (msa->nseq > 1) p7_Fail("Unable to guess query file type - could be either aligned or unaligned; please specify (--qformat)");
                   } else {
                       /* if ok, and not fasta or a2m, then it's an MSA ... proceed */
                       cfg->qfmt = qfp_msa->format;

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -654,11 +654,14 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
                   }
               }
           }
+      }  else {
+          if (esl_opt_IsOn(go, "--qsingle_seqs"))
+              p7_Fail("--qsingle_seqs flag is incompatible with an hmm-formatted query file\n");
       }
   }
 
   if (! (abc->type == eslRNA || abc->type == eslDNA))
-     p7_Fail("Invalid alphabet type in query for nhmmer. Expect DNA or RNA\n");
+     p7_Fail("Invalid alphabet type in query for nhmmer. Expect DNA or RNA.\n");
 
 
   /* nhmmer accepts _target_ files that are either (i) some sequence file format, or
@@ -699,7 +702,7 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
       int q_type = eslUNKNOWN;
       status = esl_sqfile_GuessAlphabet(dbfp, &q_type);
       if (! (q_type == eslDNA || q_type == eslRNA))
-          p7_Fail("Invalid alphabet type in target for nhmmer. Expect DNA or RNA\n");
+          p7_Fail("Invalid alphabet type in target for nhmmer. Expect DNA or RNA.\n");
 
       /*success; move forward with other necessary steps*/
       if (esl_opt_IsUsed(go, "--restrictdb_stkey") || esl_opt_IsUsed(go, "--restrictdb_n")) {

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -906,7 +906,6 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
 
       if (hmmoutfp != NULL) {
         if ((status = p7_hmmfile_WriteASCII(hmmoutfp, -1, hmm)) != eslOK) ESL_FAIL(status, errbuf, "HMM save failed");
-        fclose(hmmoutfp);
       }
 
       nquery++;
@@ -1203,6 +1202,8 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
                 qhstatus, qfp_sq->filename);
   }
 
+  if (hmmoutfp != NULL)
+        fclose(hmmoutfp);
 
  /* Terminate outputs - any last words?
    */

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -637,7 +637,7 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
                       if (msa->nseq > 1) p7_Fail("Unable to guess query file type; please specify (--qformat)");
                   } else {
                       /* if ok, and not fasta or a2m, then it's an MSA ... proceed */
-                      cfg->qfmt = eslSQFILE_UNKNOWN;
+                      cfg->qfmt = qfp_msa->format;
                   }
               }
               if ( cfg->qfmt == eslSQFILE_UNKNOWN ) { /* it's not an MSA, try seq */

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -583,22 +583,15 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
 
   /* (1)
    * If we were told a specific query file type, just do what we're told
-   * Note, the file format codes follow this rule:
-   *  - 0 is an unknown/unassigned format (eslSQFILE_UNKNOWN, eslMSAFILE_UNKNOWN)
-   *  - <=100 is reserved for sqio, for unaligned formats
-   *  - >100  is reserved for msa, for aligned formats
-   *
-   *  These values follow the rules laid out in esl_msa.h and esl_sqio.h
    */
-  if (cfg->qfmt > 100 /* msa file */) {
+  if (esl_sqio_IsAlignment(cfg->qfmt) /* msa file */) {
       status = nhmmer_open_msa_file(cfg, &qfp_msa, &abc, &msa);
       if (status != eslOK) p7_Fail("Error reading msa from file %s (%d)\n", cfg->queryfile, status);
-  } else if (cfg->qfmt > 0 /* sequence file */) {
+  } else if (cfg->qfmt != eslSQFILE_UNKNOWN /* sequence file */) {
       status = nhmmer_open_seq_file(cfg, &qfp_sq, &abc, &qsq);
       if (status != eslOK) p7_Fail("Error reading sequence from file %s (%d)\n", cfg->queryfile, status);
   }
-
-
+  
 
 /* (2)
  * Guessing query format.

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -451,12 +451,6 @@ nhmmer_open_msa_file(struct cfg_s *cfg,  ESL_MSAFILE **qfp_msa, ESL_ALPHABET **a
     int status = esl_msafile_Open(abc, cfg->queryfile, NULL, cfg->qfmt, NULL, qfp_msa);
     if (status == eslENOTFOUND) p7_Fail("File existence/permissions problem in trying to open query file %s.\n", cfg->queryfile);
     if (status == eslOK) {
-        if (*abc == NULL) {
-            int q_type = eslUNKNOWN;
-            esl_msafile_GuessAlphabet(*qfp_msa, &q_type);
-            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for query file %s\n", cfg->queryfile);
-            *abc = esl_alphabet_Create(q_type);
-        }
         status = esl_msafile_Read(*qfp_msa, msa);
     }
     return status;
@@ -662,6 +656,9 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
           }
       }
   }
+
+  if (! (abc->type == eslRNA || abc->type == eslDNA))
+     p7_Fail("Invalid alphabet type in query for nhmmer. Expect DNA or RNA\n");
 
 
   /* nhmmer accepts _target_ files that are either (i) some sequence file format, or

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -475,6 +475,7 @@ nhmmer_open_seq_file (struct cfg_s *cfg, ESL_SQFILE **qfp_sq, ESL_ALPHABET **abc
                 && status == eslEFORMAT /* format error most likely to be due to presence of a gap character, so it's really an afa file */
                 && used_qsingle_seqs  /* we were instructed to treat the input as single seqs, so override the fasta guess/instruction, and force single-sequence handling of afa file */
                 ) {
+                esl_sqfile_Close(*qfp_sq);
                 status = esl_sqfile_Open(cfg->queryfile, eslMSAFILE_AFA, NULL, qfp_sq);
                 if (status == eslOK && *abc == NULL)
                         status = esl_sqfile_GuessAlphabet(*qfp_sq, &q_type);

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -648,6 +648,7 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
                       if (qfp_msa) {
                           esl_msafile_Close(qfp_msa);
                           qfp_msa = NULL;
+                          esl_msa_Destroy(msa);
                       }
                       status = nhmmer_open_seq_file(cfg, &qfp_sq, &abc, &qsq, esl_opt_IsOn(go, "--qsingle_seqs"));
                       if (status != eslOK) p7_Fail("Error reading query file %s (%d)\n", cfg->queryfile, status);

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -628,7 +628,7 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
                   if ( qfp_msa->format == eslMSAFILE_AFA) {
                       /* this could just be a sequence file with o single sequence (in which case, fall through
                        * to the "sequence" case), or with several same-sized sequences (in which case ask for guidance) */
-                      if (msa->nseq > 1) p7_Fail("Unable to guess query file type - could be either aligned or unaligned; please specify (--qformat)");
+                      if (msa->nseq > 1) p7_Fail("Query file type could be either aligned or unaligned; please specify (--qformat [afa|fasta])");
                   } else {
                       /* if ok, and not fasta, then it's an MSA ... proceed */
                       cfg->qfmt = qfp_msa->format;

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -696,6 +696,10 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
     else if (status == eslEINVAL)    p7_Fail("Can't autodetect format of a stdin or .gz seqfile");
     else if (status != eslOK)        p7_Fail("Unexpected error %d opening target sequence database file %s\n", status, cfg->dbfile);
     else {
+      int q_type = eslUNKNOWN;
+      status = esl_sqfile_GuessAlphabet(dbfp, &q_type);
+      if (! (q_type == eslDNA || q_type == eslRNA))
+          p7_Fail("Invalid alphabet type in target for nhmmer. Expect DNA or RNA\n");
 
       /*success; move forward with other necessary steps*/
       if (esl_opt_IsUsed(go, "--restrictdb_stkey") || esl_opt_IsUsed(go, "--restrictdb_n")) {

--- a/testsuite/testsuite.sqc
+++ b/testsuite/testsuite.sqc
@@ -473,6 +473,7 @@
 3 valgrind  hmmstat               @src/hmmstat@    %MINIFAM.HMM% 
 3 valgrind  jackhmmer             @src/jackhmmer@  !tutorial/HBB_HUMAN! !tutorial/globins45.fa!
 3 valgrind  phmmer                @src/phmmer@     !tutorial/HBB_HUMAN! !tutorial/globins45.fa!
+3 valgrind  nhmmer                @src/nhmmer@     !tutorial/MADE1.hmm! !tutorial/dna_target.fa!
 
 # some derivatives of tmpfiles created by hmmpress, not sqc itself: clean up
 1 prep     minifam                rm -f %MINIFAM.HMM%.h3f %MINIFAM.HMM%.h3p %MINIFAM.HMM%.h3m %MINIFAM.HMM%.h3i 


### PR DESCRIPTION
This is a much delayed fix for issue #171. 

If nhmmer is called without guidance on the input type, it tries to guess
whether the query is an HMM, MSA, or unaligned file of seqs. It previously
did this by trying to open the file first as an HMM, then as an MSA, and
finally as a sequence file - if it succeeded at any point, it would decide
this was the correct input type. This over-eager guessing strategy could
lead to unexpected results:
- when reading a sequence file with a single sequence, nhmmer would treat
the input as a one-sequence MSA; this is not intuitive.
- when reading a sequence file with many sequences all of the same length,
nhmmer would guess that this was an MSA, and smash them into a single query,
computing one model for the "MSA"; this is just plain wrong

This PR reimplements the format-guessing framework, still seeking to
get the guess right, but insisting that the user provide guidance if the
choice isn't completely clear. It also simplifies the logic of the guessing
code, updates documentation, and removes the --qhmm,  --qmsa, and
--qseq flags, which were redundant with --qformat. The new strategy is:

- If the user has provided guidance w/ a --qformat value do as
instructed. 

- Otherwise, try to open the file as an HMM. This either works or doesn't,
with no risk. (note: if this fails and the file is piped, it can't be
rewound, so give a "must specify format" message)
- If the file is rewindable, check to see if it's obviously an MSA file
or obviously a sequence file. If not obvious, we'll force the user to
tell us. That looks like this:
   - Try to open it as an MSA file
      - if ok (i.e. it opens and passes the MSA check, including that
        all sequences are the same length)
         - if it's a FASTA or A2M format, it still might be a sequence
           file
              - if the "MSA" is a single sequence, then rewind and call it
                a sequence input.  Otherwise give "must specify" message
         - otherwise, it's an MSA;  proceed accordingly
      - if not ok (i.e. it's not an MSA file)
         - if it's anything useful, it must be a sequence file, proceed accordingly
