### PR TITLE
Fix for Isssue #198

### DIFF
--- a/src/p7_domaindef.c
+++ b/src/p7_domaindef.c
@@ -844,7 +844,11 @@ rescore_isolated_domain(P7_DOMAINDEF *ddef, P7_OPROFILE *om, const ESL_SQ *sq, c
   p7_Backward(sq->dsq + i-1, Ld, om, ox1, ox2, NULL);
 
   status = p7_Decoding(om, ox1, ox2, ox2);      /* <ox2> is now overwritten with post probabilities     */
-  if (status == eslERANGE) return eslFAIL;      /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-121] */
+  if (status == eslERANGE) { /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-121] */
+      reparameterize_model(bg, om, NULL, 0, 0, fwd_emissions_arr, bg_tmp->f, scores_arr); /* revert to original bg model */
+      status = eslFAIL;
+      goto ERROR;
+  }
 
   /* Find an optimal accuracy alignment */
   p7_OptimalAccuracy(om, ox2, ox1, &oasc);      /* <ox1> is now overwritten with OA scores              */
@@ -894,7 +898,11 @@ rescore_isolated_domain(P7_DOMAINDEF *ddef, P7_OPROFILE *om, const ESL_SQ *sq, c
       p7_Backward(sq->dsq + i-1, Ld, om, ox1, ox2, NULL);
 
       status = p7_Decoding(om, ox1, ox2, ox2);      /* <ox2> is now overwritten with post probabilities     */
-      if (status == eslERANGE) { status = eslFAIL; goto ERROR; }  /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-212] */
+      if (status == eslERANGE) { /* rare: numeric overflow; domain is assumed to be repetitive garbage [J3/119-121] */
+          reparameterize_model(bg, om, NULL, 0, 0, fwd_emissions_arr, bg_tmp->f, scores_arr); /* revert to original bg model */
+          status = eslFAIL;
+          goto ERROR;
+      }
 
       /* Find an optimal accuracy alignment */
       p7_OptimalAccuracy(om, ox2, ox1, &oasc);      /* <ox1> is now overwritten with OA scores              */


### PR DESCRIPTION
The change in this PR is simple: in rescore_isolated_domain(), if p7_Decoding() returns eslERANGE*, then the bg model is returned to its original form via a call to reparameterize_model() before rescore_isolated_domain() returns an eslFAIL status. Previously, it just returned the eslFAIL status without recovering bg, so that all subsequent work was done with a wrong (and highly biased) bg.

* (the eslERANGE result is assumed to mean that the target appears to be repetitive garbage, see Sean's comment in the code)

I've tested this on thousands of highly-repetitive models and sequences found in the raw data for a new Dfam release, and it works as expected: the rare eslERANGE result is handled gracefully (bg model is reset as it should be, subsequent work proceeds as normal). 

I've also tested on a few hundred repetitive models/sequences against the unmasked human genome (i.e. tandem repeat regions not masked). In these runs, I have not seen any instances of the eslERANGE result from p7_Decoding().  Considering the repetitiveness of the queries, I expect in-the-wild occurrence of this bug to be quite low.