### PR TITLE
add install-strip target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ ifndef V
 		        ${MAKE} -s -C $$subdir
 endif
 
-.PHONY: all dev check pdf install uninstall clean distclean TAGS
+.PHONY: all dev check pdf install install-strip uninstall clean distclean TAGS
 
 # all: Compile all documented executables.
 #      (Excludes test programs.)
@@ -133,6 +133,14 @@ install: all
 	${INSTALL} -d ${DESTDIR}${bindir}
 	${INSTALL} -d ${DESTDIR}${man1dir}
 	${MAKE} -C src install
+	${MAKE} -C documentation install
+
+# install-strip: same as install, but strip binaries
+#
+install-strip: all
+	${INSTALL} -d ${DESTDIR}${bindir}
+	${INSTALL} -d ${DESTDIR}${man1dir}
+	${MAKE} -C src install-strip
 	${MAKE} -C documentation install
 
 # uninstall: reverses the steps of "make install".

--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,7 @@ AX_PROG_CC_MPI([test x"$enable_mpi" = xyes],
 AC_PROG_CC_STDC
 AC_PROG_CPP
 AC_PROG_INSTALL
+AC_CHECK_TOOL([STRIP],[strip])
 AC_PROG_RANLIB
 AC_PATH_PROG([AR], [ar], [:], [$PATH:/usr/ccs/bin:/usr/xpg4/bin])
 AC_PROG_LN_S

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -32,6 +32,7 @@ LIBS           = -lhmmer -leasel -ldivsufsort  @LIBS@ @LIBGSL@ @PTHREAD_LIBS@ -l
 
 AR        = @AR@ 
 RANLIB    = @RANLIB@
+STRIP     = @STRIP@
 INSTALL   = @INSTALL@
 
 IMPLDIR   = impl_@IMPL_CHOICE@
@@ -242,7 +243,7 @@ ifndef V
 		        ${MAKE} -s -C $$subdir
 endif
 
-.PHONY: all dev tests check install uninstall distclean clean TAGS
+.PHONY: all dev tests check install install-strip uninstall distclean clean TAGS
 
 all:   ${PROGS} ${AUXPROGS} .FORCE
 
@@ -340,6 +341,12 @@ ${EXAMPLES}: libhmmer.a ${HDRS} p7_config.h
 
 install:
 	for file in ${PROGS}; do \
+	   ${INSTALL} -m 0755 $$file ${DESTDIR}${bindir}/ ;\
+	done
+
+install-strip:
+	for file in ${PROGS}; do \
+	   ${STRIP} $$file ;\
 	   ${INSTALL} -m 0755 $$file ${DESTDIR}${bindir}/ ;\
 	done
 


### PR DESCRIPTION
This PR adds a 'install-strip' target, allowing to strip the hmmer3 binaries before installing them to the
desired target location, thereby reducing required disk space.