### PR TITLE
nhmmer fix error msg

### DIFF
--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -475,7 +475,7 @@ nhmmer_open_seq_file (struct cfg_s *cfg, ESL_SQFILE **qfp_sq, ESL_ALPHABET **abc
                         status = esl_sqfile_GuessAlphabet(*qfp_sq, &q_type);
             }
             if (status == eslEFORMAT) p7_Fail("Parse failed (sequence file %s):\n%s\n", (*qfp_sq)->filename, esl_sqfile_GetErrorBuf(*qfp_sq));
-            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for the %s%squery file %s\n", (cfg->qfmt==eslUNKNOWN ? "" : esl_sqio_DecodeFormat(cfg->qfmt)), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted"), cfg->queryfile);
+            if (q_type == eslUNKNOWN) p7_Fail("Unable to guess alphabet for the %s%s query file %s\n", (cfg->qfmt==eslUNKNOWN ? "" : esl_sqio_DecodeFormat(cfg->qfmt)), (cfg->qfmt==eslSQFILE_UNKNOWN ? "":"-formatted"), cfg->queryfile);
             *abc = esl_alphabet_Create(q_type);
         }
         if (!((*abc)->type == eslRNA || (*abc)->type == eslDNA))


### PR DESCRIPTION
Minor fix to add a space to an error message about unguessable alphabet.  Observed in issue #210
(problem message was: "Unable to guess alphabet for the FASTA-formattedquery file")