### PR TITLE
distclean modification for config.log and config.status files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -172,7 +172,7 @@ distclean:
 	${QUIET_SUBDIR0}documentation ${QUIET_SUBDIR1} distclean
 	${QUIET_SUBDIR0}${ESLDIR}     ${QUIET_SUBDIR1} distclean
 	${QUIET_SUBDIR0}${SADIR}      ${QUIET_SUBDIR1} distclean
-	${QUIET}-rm config.log config.status
+	${QUIET}-rm -f config.log config.status
 	${QUIET}-rm -rf autom4te.cache
 	${QUIET}-rm -f *.o *~ Makefile.bak core TAGS TAGS.part gmon.out
 	${QUIET}-rm -f cscope.po.out cscope.out cscope.in.out cscope.files


### PR DESCRIPTION
A minor tweak for Infernal:

Infernal's 'make distclean' calls 'make distclean' in its hmmer subdir. If configure hasn't been called in hmmer's subdir yet, then 'config.log' and 'config.status' won't exist, and a flagless 'rm' call on 'config.log' and 'config.status' will fail and exit in an error. I think the error is ignored but the distclean output still reports an error which is not ideal. This PR adds '-f' to the 'rm' call, making it mirror the analogous situation in easel's distclean commands.

I don't think this is important enough to worry about in infernal 1.1.4 which will include hmmer 3.3.2. 