### PR TITLE
Fix for nhmmer memory error - issue 213

### DIFF
--- a/src/makehmmerdb.c
+++ b/src/makehmmerdb.c
@@ -657,6 +657,7 @@ main(int argc, char **argv)
       if (block->list[i].desc == NULL) meta->seq_data[numseqs].desc[0] = '\0';
           else  strcpy(meta->seq_data[numseqs].desc, block->list[i].desc );
 
+      meta->seq_data[numseqs].length = 0;
       for (j=1; j<=block->list[i].n; j++) {
         c = abc->sym[block->list[i].dsq[j]];
         if ( meta->alph_type == fm_DNA) {


### PR DESCRIPTION
This is a fix for https://github.com/EddyRivasLab/hmmer/issues/213.
The error was caused by incorrect sizes for some of the sequence elements
in the data structure underlying the FM-index-based binary representation
of the sequence database created with makehmmerdb. The error was a simple
matter of failing to initialize the value to zero before accumulating
length while reading the sequence (i.e. lengths could be effectively
random under certain memory access conditions).

Though the original issue only found an error when nhmmer search was
performed on a database produce by running makehmmerdb with the
--block_size flag, the error also could affect databases produced without
any makehmmerdb flag.