### PR TITLE
check targetdir existence before attempting to create it

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -130,16 +130,16 @@ pdf:
 #
 #          Does not use quiet beautification magic; always verbose.
 install: all
-	${INSTALL} -d ${DESTDIR}${bindir}
-	${INSTALL} -d ${DESTDIR}${man1dir}
+	if [ ! -d ${DESTDIR}${bindir} ]; then ${INSTALL} -d ${DESTDIR}${bindir}; fi
+	if [ ! -d ${DESTDIR}${man1dir} ]; then ${INSTALL} -d ${DESTDIR}${man1dir}; fi
 	${MAKE} -C src install
 	${MAKE} -C documentation install
 
 # install-strip: same as install, but strip binaries
 #
 install-strip: all
-	${INSTALL} -d ${DESTDIR}${bindir}
-	${INSTALL} -d ${DESTDIR}${man1dir}
+	if [ ! -d ${DESTDIR}${bindir} ]; then ${INSTALL} -d ${DESTDIR}${bindir}; fi
+	if [ ! -d ${DESTDIR}${man1dir} ]; then ${INSTALL} -d ${DESTDIR}${man1dir}; fi
 	${MAKE} -C src install-strip
 	${MAKE} -C documentation install
 


### PR DESCRIPTION
make install{,-strip} fails if $PREFIX/{bin,share/man/man1} already exists as a directory but is owned by a different user:

```
[sjaenick@piggy:/vol/mgx-sw/src/tools/hmmer-3.3.2 ]$ make install
     SUBDIR easel
     SUBDIR miniapps
     SUBDIR libdivsufsort
     SUBDIR src
     SUBDIR impl_sse
     SUBDIR profmark
/usr/bin/install -c -d /vol/mgx-sw/bin
/usr/bin/install: cannot change permissions of ‘/vol/mgx-sw/bin’: Permission denied
Makefile:133: recipe for target 'install' failed
make: *** [install] Error 1
[sjaenick@piggy:/vol/mgx-sw/src/tools/hmmer-3.3.2 ]$ ls -ld /vol/mgx-sw/bin/
drwxrws--- 2 root mgxserv 9112 Jan 29 14:38 /vol/mgx-sw/bin/
```

This PR adds additional checks to the Makefile, only attempting to create the relevant directories if they don't exist yet.