### PR TITLE
Fix for large loss in hits using nhmmer w/ FM #172

### DIFF
--- a/src/fm_ssv.c
+++ b/src/fm_ssv.c
@@ -319,7 +319,6 @@ FM_Recurse( int depth, int Kp, int fm_direction,
             || ( dp_pairs[i].model_direction == fm_backward && k == 1 )                                             //can't extend anymore, 'cause we're at the beginning of the model, going backwards
             || (depth == dp_pairs[i].score_peak_len + fm_cfg->drop_max_len)                                        //too many consecutive positions with a negative total score contribution (sort of like Xdrop)
             || (depth > 4 && depth > consec_consensus && (float)sc/(float)depth < fm_cfg->score_density_req)       //score density is too low (don't bother checking in the first couple slots
-            || (depth >= 0.7*fm_cfg->max_depth && depth > consec_consensus &&  (float)sc/(float)depth < sc_threshFM/(float)(fm_cfg->max_depth))                      // if we're most of the way across the sequence, and score density is too low, abort -- if the density on the other side is high enough, I'll find it on the reverse sweep
             || (dp_pairs[i].max_consec_pos < fm_cfg->consec_pos_req  &&                                               //a seed is expected to have at least one run of positive-scoring matches at least length consec_pos_req;  if it hasn't,  (see Tue Nov 23 09:39:54 EST 2010)
                 (fm_cfg->consec_pos_req - positive_run) ==  (fm_cfg->max_depth - depth + 1)                 // if we're close to the end of the sequence, abort -- if that end does have sufficiently long all-positive run, I'll find it on the reverse sweep
                )

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -121,13 +121,13 @@ static ESL_OPTIONS options[] = {
 #if defined (eslENABLE_SSE)
   /* Control of FM pruning/extension */
   { "--seed_max_depth",    eslARG_INT,          "15", NULL, NULL,    NULL,  NULL, NULL,          "seed length at which bit threshold must be met",             9 },
-  { "--seed_sc_thresh",    eslARG_REAL,         "15", NULL, NULL,    NULL,  NULL, NULL,          "Default req. score for FM seed (bits)",                      9 },
-  { "--seed_sc_density",   eslARG_REAL,        "0.8", NULL, NULL,    NULL,  NULL, NULL,          "seed must maintain this bit density from one of two ends",   9 },
+  { "--seed_sc_thresh",    eslARG_REAL,         "14", NULL, NULL,    NULL,  NULL, NULL,          "Default req. score for FM seed (bits)",                      9 },
+  { "--seed_sc_density",   eslARG_REAL,       "0.75", NULL, NULL,    NULL,  NULL, NULL,          "seed must maintain this bit density from one of two ends",   9 },
   { "--seed_drop_max_len", eslARG_INT,           "4", NULL, NULL,    NULL,  NULL, NULL,          "maximum run length with score under (max - [fm_drop_lim])",  9 },
   { "--seed_drop_lim",     eslARG_REAL,        "0.3", NULL, NULL,    NULL,  NULL, NULL,          "in seed, max drop in a run of length [fm_drop_max_len]",     9 },
   { "--seed_req_pos",      eslARG_INT,           "5", NULL, NULL,    NULL,  NULL, NULL,          "minimum number consecutive positive scores in seed" ,        9 },
   { "--seed_consens_match", eslARG_INT,         "11", NULL, NULL,    NULL,  NULL, NULL,          "<n> consecutive matches to consensus will override score threshold" , 9 },
-  { "--seed_ssv_length",   eslARG_INT,          "70", NULL, NULL,    NULL,  NULL, NULL,          "length of window around FM seed to get full SSV diagonal",   9 },
+  { "--seed_ssv_length",   eslARG_INT,         "100", NULL, NULL,    NULL,  NULL, NULL,          "length of window around FM seed to get full SSV diagonal",   9 },
 #endif
 
 /* Other options */


### PR DESCRIPTION
This addresses https://github.com/EddyRivasLab/hmmer/issues/172.

Refresher:
nhmmer can be used to search for query sequences in a target database
by either (a) directly searching the target sequences with the standard
HMMER filter pipeline, or (b) first creating a binary index of the
target (using makehmmerdb), then using that index to find high-scoring
ungapped seeds that are then passed through the remaining pipeline.

The problem was that (b) was producing substantially fewer hits than
(a), and many of the missed hits were high-quality matches e.g.
E-value < 1e-40.

The issue was raised by Nick Carter, after a routine search for
homologs in a dataset of Saccharomycotina scaffolds. The error isn't
unique to this dataset, but I was able to reproduce by searching with
a set of query sequences provided by Nick against assembled scaffolds
from:
https://mycocosm.jgi.doe.gov/saccharomycotina/saccharomycotina.info.html
(The JGI scaffold file is ~1.3Gb;  I will upload the query file in the
pull request that follows this commit).

With a saccharomycotina dataset downloaded 01/15/2021 (89 scaffolds),
(a) produced 255 matches, while (b) produced only 195. One of the hits
from (a) that was missed by (b) had an E-value of 4.2e-71. Yuck.

I initially thought the missing hits were the result of a bug in the
FM index implementation used as the basis of the binary index. After
much inspection, I couldn't find such an FM-index bug, and (finally)
realized that each of the missed hits really does fail to pass the
precise filtering criteria used in the seed-finding stage (or the
seed-extension stage that immediately follows).

A refresher on that pipeline:
- A seed involves some region of the target sequence aligned against
some part of the query, and must reach a target score S within some
specified length L. By default, that was S=15 bits within a length
L=15 ungapped run.
- The space of possible seeds is explored by enumerating all length-L
strings, growing strings to produce the enumeration. During this
enumeration, substrings are pruned (not extended to reach length L)
if they fail to meet particular conditions:
   - at some length L'<L, it's clear that there is no possible extension
     of the growing seed that can possibly reach the score S by
     length L.
   - at L', their score density is below some threshold
     (0.8 bits/position),
   - and a few others ad hoc filtering criteria.

(1) During development of the FM-accelerated pipeline for nhmmer,
testing was performed with HMM queries, not single-sequence queries.
The per-position scores produced by nhmmer for single-sequence queries
are pretty low, so it is quite likely (depending on the specific letters)
that a length-15 ungapped alignment with 2 mismatches will not reach
15 bits. In other words, the seeding mechanism almost requires seeds in
which 14 of 15 positions are identical. That's too stringent. Changing
the cutoff to "14 bits" recovers a large number of the missed hits, at
<10% increase in run time. (note, they usually still need to have 13/15)
I'm hesitant to go lower than that, and speed really starts to drop off.

(2) Even so, aligned regions with mismatch(es) in the middle sometimes
reduce score density enough to cause the match to be filtered by the
score density criteria. These regions look like this:
     taccagctaggtaat
     taccag t ggtaat
     TACCAGTTGGGTAAT
The density filter is an integral part of the speed of the indexing
approach, so can't be removed ... but by slightly loosening it
(to a default of 0.75), we recover more lost matches.

(3) Finally, regions like the one above also highlighted the failings
of an additional (ill-advised) density-based pruning condition that
I've now removed entirely. After a certain length of candidate seed
(e.g. length=11 by default), the growing seed was required to have
score density at least as high as the final target density
(previously S/L = 15/15 = 1.0). I thought this was a safe extra
filter because the index considers seeds in both directions, and
I believed that a miss in the forward pass would mean there must be
sufficient density in the reverse pass to ensure survival. This
failed to allow for the fact that an alignment with a single
mismatch in the middle will have a density dip in both directions.
In that case, both directions will get pruned before picking up
the score to recover the match (even if the density from (2) above
is met). I've removed this ad hoc filter; it has little appreciable
impact on speed, but allows recovery of several previously-missed
matches.

(4) Finally, I found that several matches were missed because nhmmer
takes an identified seed, and extends it to an ungapped (SSV) alignment
of length at most 70 - if the target SSV score isn't reached by then,
the comparison is quit. By extending this value to 100, several
additional hits were recovered.

So in total:
- I've removed one ill-advised seed pruning condition
- I've reduced the default score threshold (--seed_sc_thresh) to 14.0
- I've reduced the default req'd score density (--seed_sc_density)
  to 0.75
- I've increased the default ssv diagonal length (--seed_ssv_length)
  to 100

The result is that the FM-accelerated nhmmer run time has increased
a bot over 10%, and 247 hits are found in the above dataset. Most of
those still missed hits are good scoring ones (e.g. E-value 1e-14),
but not great. In one case the FM-accelerated pipeline binds together
a hit that was split into two hits by the standard pipeline. In a
single other case, a very good-scoring hit (1e-40) is missed by the
FM-based pipeline - that match's alignment has the perfect pathological
form (no good runs of nearly all identity) to flummox the seed stage
as it is currently designed. That's true for all the lesser hits as
well. They should clearly be caught, but doing so will require a change
to the seed stage so that it either seeks multiple shorter matches
or uses spaced seed methods. We are currently working on these, so
I think this will eventually be addressed ... but for now, it's the
best nhmmer can do.