### PR TITLE
Fix alimask out-of-range errors (iss #237)

### DIFF
--- a/documentation/man/alimask.man.in
+++ b/documentation/man/alimask.man.in
@@ -109,15 +109,37 @@ The default is to overwrite any existing mask.
 
 .TP
 .BI \-\-model2ali " <s>"
-Rather than actually produce the masked alignment, simply
-print model range(s) corresponding to input alignment 
-range(s).
+Print model range(s) and the corresponding alignment range(s).
+No masked alignment is produced.
+The output is a single line for each input range, of the form
+.nf
+   i..j -> m..n
+.fi
+with i & j representing model range values, and m & n
+representing alignment range values.
 
 .TP
 .BI \-\-ali2model " <s>"
-Rather than actually produce the masked alignment, simply
-print alignment range(s) corresponding to input model 
-range(s).
+Print alignment range(s) and the corresponding model range(s).
+No masked alignment is produced.
+Because some alignment positions may not map to model positions,
+the range(s) produced will begin with the first alignment
+position between <from> and <to> (inclusive) that maps to a
+model position, and end with the final alignment position in
+that range that maps to a model position.
+The output is a single line for each input range, of
+the form
+.nf
+  i..j -> m..n
+.fi
+with i & j representing alignment range values, and m & n
+representing model range values.
+If no alignment positions in the range <from>..<to> map
+to a model position, the output prints the input <from>
+and <to> mapping to nothing, with the format:
+.nf
+ i..j  ->   \-..\-  (no map) .
+.fi
 
 
 .SH OPTIONS FOR SPECIFYING THE ALPHABET

--- a/documentation/man/alimask.man.in
+++ b/documentation/man/alimask.man.in
@@ -103,7 +103,7 @@ Supply the given range(s) in model coordinates.
 Supply the given range(s) in alignment coordinates. 
 
 .TP
-.B \-\-apendmask 
+.B \-\-appendmask 
 Add to the existing mask found with the alignment.
 The default is to overwrite any existing mask. 
 

--- a/src/alimask.c
+++ b/src/alimask.c
@@ -265,6 +265,7 @@ main(int argc, char **argv)
   int64_t       pos1, pos2;       // esl_regexp_ParseCoordString() works in int64_t coords now; this is a hackaround
 
   char         *rangestr;
+  char         *rangestr_ptr;
   char         *range;
 
 
@@ -315,6 +316,7 @@ main(int argc, char **argv)
   } else {
     if (puts("Must specify mask range with --modelrange, --alirange, --model2ali, or --ali2model\n") < 0) ESL_XEXCEPTION_SYS(eslEWRITE, "write failed"); goto ERROR;
   }
+  rangestr_ptr = rangestr;
 
   while ( (status = esl_strtok(&rangestr, ",", &range) ) == eslOK) {
     status = esl_regexp_ParseCoordString(range, &pos1, &pos2);
@@ -330,7 +332,7 @@ main(int argc, char **argv)
     mask_range_cnt++;
   }
 
-
+  free(rangestr_ptr);
   /* Start timing. */
   esl_stopwatch_Start(w);
 
@@ -469,7 +471,9 @@ main(int argc, char **argv)
   if (esl_opt_IsOn(go, "-o"))  fclose(ofp);
   if (postmsafp) fclose(postmsafp);
   if (afp)       esl_msafile_Close(afp);
+  if (msa)       esl_msa_Destroy(msa);
   if (abc)       esl_alphabet_Destroy(abc);
+  if (model2ali_map) free(model2ali_map);
 
   esl_getopts_Destroy(go);
   esl_stopwatch_Destroy(w);

--- a/src/alimask.c
+++ b/src/alimask.c
@@ -57,9 +57,9 @@ static ESL_OPTIONS options[] = {
 /* mask ranges */
   { "--modelrange", eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "range(s) for mask(s) in model coordinates", 5 },
   { "--alirange",   eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "range(s) for mask(s) in alignment coordinates", 5 },
-  { "--apendmask",    eslARG_NONE, NULL, NULL, NULL,  NULL,  WGTOPTS,         NULL,  "add to existing mask (default ignores to existing mask)",    5 },
-  { "--model2ali",  eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "given model ranges, print corresp. input alignment ranges", 5 },
-  { "--ali2model",  eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "given alignment ranges, print corresp. model ranges", 5 },
+  { "--appendmask",    eslARG_NONE, NULL, NULL, NULL,  NULL,  WGTOPTS,         NULL,  "add to existing mask (default ignores the existing mask)",    5 },
+  { "--model2ali",  eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "print msa column range for each input model range; no postmsa", 5 },
+  { "--ali2model",  eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "print model range for each input msa column range; no postmsa", 5 },
 
 /* Other options */
   { "--informat", eslARG_STRING,      NULL,    NULL, NULL,   NULL,   NULL,  NULL, "assert input alifile is in format <s> (no autodetect)", 8 },
@@ -70,7 +70,7 @@ static ESL_OPTIONS options[] = {
 
 
 static char usage[]  = "[-options] <msafile> <postmsafile>";
-static char banner[] = "appending modelmask line to a multiple sequence alignments";
+static char banner[] = "append modelmask line to a multiple sequence alignment";
 
 static int output_header(const ESL_GETOPTS *go, FILE *ofp, char *alifile, char *postmsafile);
 

--- a/src/alimask.c
+++ b/src/alimask.c
@@ -438,6 +438,7 @@ main(int argc, char **argv)
          * that maps to a model position, and ending with the final ali position in that range
          * that maps to a model position
          */
+        alistart=0;
         while (model2ali_map[alistart] < mask_starts[i] )                    alistart++;
         aliend = alistart;
         while (aliend < model_len && model2ali_map[aliend] <= mask_ends[i])  aliend++;

--- a/src/alimask.c
+++ b/src/alimask.c
@@ -353,7 +353,7 @@ main(int argc, char **argv)
 
   if (esl_opt_IsUsed(go, "--alirange") || esl_opt_IsUsed(go, "--modelrange") ) {
     postmsafp = fopen(postmsafile, "w");
-    if (postmsafp == NULL) p7_Fail("Failed to MSA output file %s for writing", postmsafile);
+    if (postmsafp == NULL) p7_Fail("Failed to open MSA output file %s for writing", postmsafile);
   }
 
   if (esl_opt_IsUsed(go, "-o")) 

--- a/src/alimask.c
+++ b/src/alimask.c
@@ -57,7 +57,7 @@ static ESL_OPTIONS options[] = {
 /* mask ranges */
   { "--modelrange", eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "range(s) for mask(s) in model coordinates", 5 },
   { "--alirange",   eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "range(s) for mask(s) in alignment coordinates", 5 },
-  { "--appendmask",    eslARG_NONE, NULL, NULL, NULL,  NULL,  WGTOPTS,         NULL,  "add to existing mask (default ignores the existing mask)",    5 },
+  { "--appendmask",    eslARG_NONE, NULL, NULL, NULL,  NULL,  NULL,         NULL,  "add to existing mask (default ignores the existing mask)",    5 },
   { "--model2ali",  eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "print msa column range for each input model range; no postmsa", 5 },
   { "--ali2model",  eslARG_STRING, NULL, NULL, NULL,  NULL,    NULL,     RANGEOPTS,  "print model range for each input msa column range; no postmsa", 5 },
 
@@ -150,7 +150,7 @@ output_header(const ESL_GETOPTS *go, FILE *ofp, char *alifile, char *postmsafile
 
   if (esl_opt_IsUsed(go, "--alirange")   && fprintf(ofp, "# alignment range:                  %s\n",        esl_opt_GetString(go, "--alirange"))  < 0) ESL_EXCEPTION_SYS(eslEWRITE, "write failed");
   if (esl_opt_IsUsed(go, "--modelrange") && fprintf(ofp, "# model range:                      %s\n",        esl_opt_GetString(go, "--modelrange"))< 0) ESL_EXCEPTION_SYS(eslEWRITE, "write failed");
-  if (esl_opt_IsUsed(go, "--apendmask")  && fprintf(ofp, "# add to existing mask:             [on]\n"                                            )< 0) ESL_EXCEPTION_SYS(eslEWRITE, "write failed");
+  if (esl_opt_IsUsed(go, "--appendmask")  && fprintf(ofp, "# add to existing mask:             [on]\n"                                            )< 0) ESL_EXCEPTION_SYS(eslEWRITE, "write failed");
 
   if (esl_opt_IsUsed(go, "--model2ali")   && fprintf(ofp, "# ali ranges for model range:      %s\n",        esl_opt_GetString(go, "--model2ali"))  < 0) ESL_EXCEPTION_SYS(eslEWRITE, "write failed");
   if (esl_opt_IsUsed(go, "--ali2model")   && fprintf(ofp, "# model ranges for ali range:      %s\n",        esl_opt_GetString(go, "--ali2model"))  < 0) ESL_EXCEPTION_SYS(eslEWRITE, "write failed");
@@ -281,7 +281,7 @@ main(int argc, char **argv)
   /* Parse the command line
    */
   process_commandline(argc, argv, &go, &alifile, &postmsafile);
-  keep_mm = esl_opt_IsUsed(go, "--apendmask");
+  keep_mm = esl_opt_IsUsed(go, "--appendmask");
 
   /* Initialize what we can in the config structure (without knowing the alphabet yet).
    * Fields controlled by masters are set up in usual_master() or mpi_master()

--- a/src/alimask.c
+++ b/src/alimask.c
@@ -188,13 +188,14 @@ output_header(const ESL_GETOPTS *go, FILE *ofp, char *alifile, char *postmsafile
  *            do_hand - TRUE when the model is to follow a hand-build RF line (which must be
  *                      part of the file.
  *            symfraq - if weighted occupancy exceeds this value, include the column in the model.
- *            map     - int array into which the map values will be stored. Calling function
- *                      must allocate (msa->alen+1) ints.
+ *            model2ali_map - int array into which we will store the values that map positions
+ *                            in the model back to the responsible map column.
+ *                            Calling function must allocate (msa->alen+1) ints.
  *
  * Returns:   The number of mapped model positions.
  */
 int
-p7_Alimask_MakeModel2AliMap(ESL_MSA *msa, int do_hand, float symfrac, int *map )
+p7_Alimask_MakeModel2AliMap(ESL_MSA *msa, int do_hand, float symfrac, int *model2ali_map)
 {
   int      i = 0;
   int      apos, idx;
@@ -207,7 +208,7 @@ p7_Alimask_MakeModel2AliMap(ESL_MSA *msa, int do_hand, float symfrac, int *map )
      /* Watch for off-by-one. rf is [0..alen-1]*/
      for (apos = 1; apos <= msa->alen; apos++) {
        if (!esl_abc_CIsGap(msa->abc, msa->rf[apos-1]) ) {
-         map[i] = apos;
+         model2ali_map[i] = apos;
          i++;
        }
      }
@@ -225,7 +226,7 @@ p7_Alimask_MakeModel2AliMap(ESL_MSA *msa, int do_hand, float symfrac, int *map )
         }
 
         if (r > 0. && r / totwgt >= symfrac) {
-          map[i] = apos;
+          model2ali_map[i] = apos;
           i++;
         }
     }
@@ -259,14 +260,16 @@ main(int argc, char **argv)
   int           mask_range_cnt = 0;
   uint32_t      mask_starts[100]; // over-the-top allocation.
   uint32_t      mask_ends[100];
+  uint32_t      min_mask_start = 0xFFFFFFFF;
+  uint32_t      max_mask_end   = 0;
   int64_t       pos1, pos2;       // esl_regexp_ParseCoordString() works in int64_t coords now; this is a hackaround
 
   char         *rangestr;
   char         *range;
 
 
-  int     *map = NULL; /* map[i]=j,  means model position i comes from column j of the alignment; 1..alen */
-
+  int    *model2ali_map = NULL; /* model2ali_map[i]=j,  means model position i comes from column j of the alignment; 1..alen */
+  int    model_len = 0;
   int    keep_mm;
 
   /* Set processor specific flags */
@@ -284,7 +287,7 @@ main(int argc, char **argv)
    * Fields used by workers are set up in mpi_worker()
    */
   ofp         = NULL;
-  infmt         = eslMSAFILE_UNKNOWN;
+  infmt       = eslMSAFILE_UNKNOWN;
   afp         = NULL;
   abc         = NULL;
 
@@ -315,8 +318,13 @@ main(int argc, char **argv)
 
   while ( (status = esl_strtok(&rangestr, ",", &range) ) == eslOK) {
     status = esl_regexp_ParseCoordString(range, &pos1, &pos2);
-    if (status == eslESYNTAX) esl_fatal("range flags take coords <from>..<to>; %s not recognized", range);
+    if (status == eslESYNTAX) esl_fatal("Range flags take coords <from>..<to>; %s not recognized", range);
     if (status == eslFAIL)    esl_fatal("Failed to find <from> or <to> coord in %s", range);
+    if (pos1 > pos2)          esl_fatal("In range (%s) <from> can not be larger than <to>", range);
+
+    if (pos1<min_mask_start) min_mask_start = pos1;
+    if (pos2>max_mask_end)   max_mask_end   = pos2;
+
     mask_starts[mask_range_cnt] = (uint32_t) pos1;
     mask_ends[mask_range_cnt]   = (uint32_t) pos2;
     mask_range_cnt++;
@@ -362,6 +370,11 @@ main(int argc, char **argv)
   /* read the alignment */
   if ((status = esl_msafile_Read(afp, &msa)) != eslOK)  esl_msafile_ReadFailure(afp, status);
 
+  if (min_mask_start <= 0)                        esl_fatal("Mask ranges can not start before position 1; start %d is invalid", min_mask_start);
+
+  if (esl_opt_IsUsed(go, "--alirange") || esl_opt_IsUsed(go, "--ali2model"))
+      if (max_mask_end > msa->alen)               esl_fatal("Maximum mask range %d exceeds alignment length %lld", max_mask_end, msa->alen);
+
 
   if (esl_opt_IsUsed(go, "--alirange") || esl_opt_IsUsed(go, "--modelrange") ) {
     /* add/modify mmline for the mask */
@@ -395,14 +408,17 @@ main(int argc, char **argv)
     if ((status =  esl_msa_MarkFragments_old(msa, esl_opt_GetReal(go, "--fragthresh")))           != eslOK) goto ERROR;
 
     //build a map of model mask coordinates to alignment coords
-    ESL_ALLOC(map, sizeof(int)     * (msa->alen+1));
-    p7_Alimask_MakeModel2AliMap(msa, do_hand, symfrac, map );  // Returns <L>, which we don't need.
+    ESL_ALLOC(model2ali_map, sizeof(int)     * (msa->alen+1));
+    model_len = p7_Alimask_MakeModel2AliMap(msa, do_hand, symfrac, model2ali_map );
+
+    if (esl_opt_IsUsed(go, "--modelrange") || esl_opt_IsUsed(go, "--model2ali"))
+        if (max_mask_end >model_len) esl_fatal("Maximum mask range %d exceeds computed model length %lld", max_mask_end, model_len);
 
     if ( esl_opt_IsUsed(go, "--model2ali") ) {
       //print mapping
       printf ("model coordinates     alignment coordinates\n");
       for (i=0; i<mask_range_cnt; i++)
-        printf ("%8d..%-8d -> %8d..%-8d\n", mask_starts[i], mask_ends[i], map[mask_starts[i]-1], map[mask_ends[i]-1]);
+        printf ("%8d..%-8d -> %8d..%-8d\n", mask_starts[i], mask_ends[i], model2ali_map[mask_starts[i]-1], model2ali_map[mask_ends[i]-1]);
       /* If I wanted to, I could print all the map values independently:
         printf("\n\n-----------\n");
         printf("Map\n");
@@ -411,25 +427,30 @@ main(int argc, char **argv)
           printf("%d -> %d\n", i+1, map[i]);
       */
     } else if ( esl_opt_IsUsed(go, "--ali2model") ) {
-      //print mapping  (requires scanning the inverted map
+      //print mapping  (requires scanning the inverted map)
       int alistart = 0;
       int aliend = 0;
       printf ("alignment coordinates     model coordinates\n");
       for (i=0; i<mask_range_cnt; i++) {
-        //find j for ali positions
-        while (map[alistart] < mask_starts[i] )
-          alistart++;
+        /* find j for ali positions, starting with the first ali position between <from> and <to> (inclusive)
+         * that maps to a model position, and ending with the final ali position in that range
+         * that maps to a model position
+         */
+        while (model2ali_map[alistart] < mask_starts[i] )                    alistart++;
         aliend = alistart;
-        while (map[aliend] < mask_ends[i] )
-          aliend++;
+        while (aliend < model_len && model2ali_map[aliend] <= mask_ends[i])  aliend++;
+        aliend--;
 
-        printf ("   %8d..%-8d -> %8d..%-8d\n", map[alistart], map[aliend], alistart+1, aliend+1);
+        if (model2ali_map[alistart] > mask_ends[i])
+            printf("   %8d..%-8d ->       -..-  (no map)\n", mask_starts[i], mask_ends[i]);
+        else
+            printf ("   %8d..%-8d -> %8d..%-8d\n", model2ali_map[alistart], model2ali_map[aliend], alistart+1, aliend+1);
       }
     } else {
       //convert the mask coords based on map
       for (i=0; i<mask_range_cnt; i++) {
-          mask_starts[i] = map[mask_starts[i]-1]; //-1 because mmline is offset by one relative to the 1-base alignment
-          mask_ends[i]   = map[mask_ends[i]-1];
+          mask_starts[i] = model2ali_map[mask_starts[i]-1]; //-1 because mmline is offset by one relative to the 1-base alignment
+          mask_ends[i]   = model2ali_map[mask_ends[i]-1];
       }
     }
   }


### PR DESCRIPTION
This commit addresses issue #237:

"Alimask crashes if asked to mask an alignment in a region that's outside the range of the alignment."

I've added range checks on all four of --alirange, --modelrange, --ali2model, and --model2ali. For all four:
- the smallest among all `<from>` positions must be >0
- for all ranges, `<to>` can not be less that `<from>`
- the largest among `<to>` positions is restricted as is described in the next paragraphs.

For (--alirange, --ali2model): `<to>` can not exceed the alignment length.

For (--modelrange, --model2ali):
- alimask works as before, computing the model that would be produced by hmmbuild (by numerous flags mirroring those from hmmbuild).
- for all ranges, `<to>` can not exceed the resulting model length.

The --ali2model required a bit of extra attention:
The purpose of this flag is to print, for each alignment range `<from>..<to>`, a mapping of the range with two pairs i..j => m..n,
such that
- i<=j
- i is the first alignment position between `<from>` and `<to>` (inclusive) that maps to a model position; that position is m
- j is the final alignment position between `<from>` and `<to>` (inclusive) that maps to a model position; that position is n

There were two bugs in this code. The first allowed j to exceed `<to>` if the `<to>` column did not map to a model position. This is fixed. The second allowed a range-pair i..j => m..n to be produced even if no alignment columns in the range `<from>..<to>` map to a model position. I've revised the mask output to indicate this lack of mapped positions with an output like:
          `<from>..<to>       ->       -..-  (no map)`