### PR TITLE
Fix "Invalid alphabet type" error in nhmmer - iss#271

### DIFF
--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -701,7 +701,16 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
     else if (status != eslOK)        p7_Fail("Unexpected error %d opening target sequence database file %s\n", status, cfg->dbfile);
     else {
       int q_type = eslUNKNOWN;
-      esl_sqfile_GuessAlphabet(dbfp, &q_type);
+      if ( esl_opt_IsOn(go, "--dna") )
+          q_type     = eslDNA;
+      else if ( esl_opt_IsOn(go, "--rna") )
+          q_type     = eslRNA;
+      else {
+          status = esl_sqfile_GuessAlphabet(dbfp, &q_type);
+          if (status != eslOK)
+              p7_Fail("Unable to guess alphabet for target sequence database file %s\n",   cfg->dbfile);
+      }
+
       /* We assume the query is the guide for alphabet type, allowing it to override
        * guesser uncertainty;  but if the guesser is certain that the target sequence
        * is a protein (or something else non-nucleotide), we fail with an error. */

--- a/src/nhmmer.c
+++ b/src/nhmmer.c
@@ -700,6 +700,9 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
     else if (status == eslEINVAL)    p7_Fail("Can't autodetect format of a stdin or .gz seqfile");
     else if (status != eslOK)        p7_Fail("Unexpected error %d opening target sequence database file %s\n", status, cfg->dbfile);
     else {
+      /* We assume the query is the guide for alphabet type, allowing it to override
+       * guesser uncertainty;  but if the guesser is certain that the target sequence
+       * is a protein (or something else non-nucleotide), we fail with an error. */
       int q_type = eslUNKNOWN;
       if ( esl_opt_IsOn(go, "--dna") )
           q_type     = eslDNA;
@@ -710,10 +713,6 @@ serial_master(ESL_GETOPTS *go, struct cfg_s *cfg)
           if (status != eslOK)
               p7_Fail("Unable to guess alphabet for target sequence database file %s\n",   cfg->dbfile);
       }
-
-      /* We assume the query is the guide for alphabet type, allowing it to override
-       * guesser uncertainty;  but if the guesser is certain that the target sequence
-       * is a protein (or something else non-nucleotide), we fail with an error. */
       if (! (q_type == eslDNA || q_type == eslRNA || q_type == eslUNKNOWN))
         p7_Fail("Invalid alphabet type in target for nhmmer. Expect DNA or RNA.\n");
 


### PR DESCRIPTION
This addresses https://github.com/EddyRivasLab/hmmer/issues/271.

In iss#271, running the command

    % nhmmer --cpu 0 --dna query.fasta target.fasta

produces the following error:

    Parse failed (sequence file assembly.fasta):
    Line 2: unexpected char A; expected FASTA to start with >

The error arises when two things are true of the first sequence
in the target file:
(1) It does not contain all four nucleotide characters (e.g.
it contains only A,C, and Ts, and has no Gs)
(2) It is longer than the buffer length used when reading a
sequence in nhmmer (4000)

What's happening is:
(1) nhmmer calls esl_sqfile_GuessAlphabet() for the target sequence,
even if the --dna (or --rna) flag is set (around line 704 of nhmmer.c).
  - This is bad. It should respect the --dna/--rna flag.
  - That's fixed in this commit.
  - But supposing --dna/--rna weren't used, we would like this to
    be done (and done correctly), so let's dig deeper into what's
    happening:
(2) That function calls esl_sq_GuessAlphabet(), which returns the
status eslENOALPHABET, causing esl_sqfile_GuessAlphabet() to return,
and skipping the code that usually resets the buffer pointer. That
failure to reset the buffer pointer shouldn't be a problem (the
function is returning an error, after all!), but it explains the
error message we'll see later.
(3) esl_sqfile_GuessAlphabet() immediately returns to nhmmer,
returning the eslENOALPHABET status.
(4) nhmmer fails to check the returned status, and continues
processing.
  (i) It should respond to the status by alerting the user with
  an appropriate error message. It doesn't do that, which is bad.
  (ii) Because the buffer pointer wasn't reset, and processing
  continues, the next ReadWindow call in nhmmer starts reading
  from the buffer at the 4001st character of the target sequence.
  When it tries to read the header starting at the buffer position,
  it sees some character other than '>', and throws an error, with
  a confusing message.
This is solved by capturing the esl_sqfile_GuessAlphabet() status
and throwing an error if appropriate (duh). That now happens in
this commit.

So overall, the commit
(i) obeys the --dna/--rna flag, so that it only bothers to call
esl_sqfile_GuessAlphabet() on the target if it hasn't been told.
(ii) checks the status returned by esl_sqfile_GuessAlphabet(),
and reacts appropriately.